### PR TITLE
copy account keys in `run.sh` everytime, make the command cross-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+chainData/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ This is a Docker image for a single-node PoA Parity blockchain, for dev testing 
 
 ## Getting started
 
-You can build the image using sudo ./build.sh. The key files for the test accounts are under config/keysBkup, which will be copied to chainData/keys (where Parity will be looking for them) by calling ./copyKeys.sh. Note that since Docker runs as root, files created by the running image in mounted folders will be created with root:root as owner.
+You can build the image using `sudo ./build.sh`.
 
-Once the keys are in place and the image is built, sudo ./run.sh will start the container in interactive mode (ie. it will be attached to your terminal console, so you can see the messages output by the Parity instance.) Stopping Parity via ctrl+C in the console will automatically shut down the Docker image as well.
+Once the image is built, `sudo ./run.sh` will pre-populate key files for some test accounts and then start the Parity instance.
+
+The key files for the test accounts are under `config/keysBkup`, which will be copied to `chainData/keys` (where Parity will be looking for them). Note that since Docker runs as root, files created by the running image in mounted folders will be created with root:root as owner.
+
+The container will be started in interactive mode (ie. it will be attached to your terminal console, so you can see the messages output by the Parity instance.) Stopping Parity via ctrl+C in the console will automatically shut down the Docker image as well.
 
 The run.sh script has a number of port and folder mappings configured. Once the container is running, you can access the graphical UI with a browser using the address http://localhost:8180/ (this is the conventional address for a Parity GUI, so if you’re running another Parity instance, say for the Mainnet or Kovan on your machine, then you should edit run.sh to change the outside port mappings.
 

--- a/chainData/.gitignore
+++ b/chainData/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/copyKeys.sh
+++ b/copyKeys.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-cp -rT ./config/keysBkup ./chainData/keys

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,10 @@
 IMG_NAME="daniel-jozsef/parityplayground"
 DATA_ROOT=${PWD}
 
+# restore account keys from the backup folder
+mkdir -p chainData/keys
+cp -Rv config/keysBkup/* chainData/keys/
+
 docker run \
   -p 8180:8180 -p 8545:8545 -p 8546:8546 -p 30303:30303 \
   -v $DATA_ROOT/chainData:/var/parity \


### PR DESCRIPTION
# What's happening here?

This is a follow up to Pull Request https://github.com/daniel-jozsef/ParityPlayground/pull/2

Three main changes:

1. I made the `cp` command cross platform, by avoiding the `-T` option unavailable on Mac OS X (fixes bug introduced in https://github.com/daniel-jozsef/ParityPlayground/commit/effefd25cfd78d64b6d764e8bfff200f6bf03dc7 )
2. I moved commands which copy account keys to be a part of `run.sh`, to make interacting with the docker app simpler
3. I moved the `.gitignore` file to the top directory, to make it possible to "factory reset" via `rm -r chainData`

I also:

4. updated the README file accordingly
5. made copying the key files verbose

# Test plan

Running on Ubuntu for the first time:

```
ubuntu@ip-172-26-8-139:~/Repos/ParityPlayground$ sudo ./run.sh 
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-01-52Z--d0311a83-f0f6-6022-226e-3b942bf807c4' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-01-52Z--d0311a83-f0f6-6022-226e-3b942bf807c4'
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-05Z--962e5218-8b15-f891-da7d-29a76e4f5c1c' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-02-05Z--962e5218-8b15-f891-da7d-29a76e4f5c1c'
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-23Z--4f7a75f7-b1da-f3cd-9480-4b6183885b09' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-02-23Z--4f7a75f7-b1da-f3cd-9480-4b6183885b09'
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-37Z--f3f992d8-1c66-7891-2795-f137df135075' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-02-37Z--f3f992d8-1c66-7891-2795-f137df135075'
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-03-06Z--37a4c04d-6f61-951e-b43d-a5feefc731ca' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-03-06Z--37a4c04d-6f61-951e-b43d-a5feefc731ca'
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-03-47Z--98794f14-6cb2-5778-1adf-1280315035e7' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-03-47Z--98794f14-6cb2-5778-1adf-1280315035e7'
Sealer key in {config}/sealer.txt. Starting sealer node.
2018-08-14 21:58:22 UTC Starting Parity/v1.11.8-stable-92776e4-20180728/x86_64-linux-gnu/rustc1.27.2
2018-08-14 21:58:22 UTC Keys path /var/parity/keys/parityPlayground
2018-08-14 21:58:22 UTC DB path /var/parity/chains/parityPlayground/db/d75fe530a9473053
2018-08-14 21:58:22 UTC Path to dapps /var/parity/dapps
2018-08-14 21:58:22 UTC State DB configuration: fast
2018-08-14 21:58:22 UTC Operating mode: active
2018-08-14 21:58:22 UTC Configured for parityPlayground using AuthorityRound engine
2018-08-14 21:58:28 UTC Public node URL: enode://f0c947cbb0e89b51b7207f9e239d134ab722406b6d4520781203c6c8d41411804addaea0bd87e81b2ae2a48fd4a97f417d3f552ad08b9f6ed5593bab81ed9f9c@172.17.0.2:30303
2018-08-14 21:58:57 UTC    0/25 peers   8 KiB chain 7 KiB db 0 bytes queue 448 bytes sync  RPC:  0 conn,  0 req/s,   0 µs
2018-08-14 21:59:27 UTC    0/25 peers   8 KiB chain 7 KiB db 0 bytes queue 448 bytes sync  RPC:  0 conn,  0 req/s,   0 µs
2018-08-14 21:59:57 UTC    0/25 peers   8 KiB chain 7 KiB db 0 bytes queue 448 bytes sync  RPC:  0 conn,  0 req/s,   0 µs
2018-08-14 22:00:25 UTC Imported #1 0xd567…fa74 (0 txs, 0.00 Mgas, 0 ms, 0.56 KiB)
2018-08-14 22:00:27 UTC    0/25 peers   8 KiB chain 8 KiB db 0 bytes queue 448 bytes sync  RPC:  0 conn,  0 req/s,   0 µs
2018-08-14 22:00:57 UTC    0/25 peers   8 KiB chain 8 KiB db 0 bytes queue 448 bytes sync  RPC:  0 conn,  0 req/s,   0 µs
^C2018-08-14 22:00:59 UTC Finishing work, please wait...
```

Running on Ubuntu for the second time:

```
ubuntu@ip-172-26-8-139:~/Repos/ParityPlayground$ sudo ./run.sh 
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-01-52Z--d0311a83-f0f6-6022-226e-3b942bf807c4' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-01-52Z--d0311a83-f0f6-6022-226e-3b942bf807c4'
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-05Z--962e5218-8b15-f891-da7d-29a76e4f5c1c' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-02-05Z--962e5218-8b15-f891-da7d-29a76e4f5c1c'
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-23Z--4f7a75f7-b1da-f3cd-9480-4b6183885b09' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-02-23Z--4f7a75f7-b1da-f3cd-9480-4b6183885b09'
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-37Z--f3f992d8-1c66-7891-2795-f137df135075' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-02-37Z--f3f992d8-1c66-7891-2795-f137df135075'
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-03-06Z--37a4c04d-6f61-951e-b43d-a5feefc731ca' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-03-06Z--37a4c04d-6f61-951e-b43d-a5feefc731ca'
'config/keysBkup/parityPlayground/UTC--2018-02-28T13-03-47Z--98794f14-6cb2-5778-1adf-1280315035e7' -> 'chainData/keys/parityPlayground/UTC--2018-02-28T13-03-47Z--98794f14-6cb2-5778-1adf-1280315035e7'
Sealer key in {config}/sealer.txt. Starting sealer node.
2018-08-14 22:01:04 UTC Starting Parity/v1.11.8-stable-92776e4-20180728/x86_64-linux-gnu/rustc1.27.2
2018-08-14 22:01:04 UTC Keys path /var/parity/keys/parityPlayground
2018-08-14 22:01:04 UTC DB path /var/parity/chains/parityPlayground/db/d75fe530a9473053
2018-08-14 22:01:04 UTC Path to dapps /var/parity/dapps
2018-08-14 22:01:04 UTC State DB configuration: fast
2018-08-14 22:01:04 UTC Operating mode: active
2018-08-14 22:01:04 UTC Configured for parityPlayground using AuthorityRound engine
2018-08-14 22:01:10 UTC Public node URL: enode://f0c947cbb0e89b51b7207f9e239d134ab722406b6d4520781203c6c8d41411804addaea0bd87e81b2ae2a48fd4a97f417d3f552ad08b9f6ed5593bab81ed9f9c@172.17.0.2:30303
2018-08-14 22:01:39 UTC    0/25 peers   8 KiB chain 8 KiB db 0 bytes queue 448 bytes sync  RPC:  0 conn,  0 req/s,   0 µs
^C2018-08-14 22:01:48 UTC Finishing work, please wait...
```

Checking that the `.gitignore` file works properly:

```
ubuntu@ip-172-26-8-139:~/Repos/ParityPlayground$ git status
On branch copy-keys-better
Your branch is up-to-date with 'origin/copy-keys-better'.
nothing to commit, working directory clean
```

Running on Mac OS X for the first time:

```
Highgarden:ParityPlayground kkom$ ./run.sh 
config/keysBkup/parityPlayground -> chainData/keys/parityPlayground
config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-05Z--962e5218-8b15-f891-da7d-29a76e4f5c1c -> chainData/keys/parityPlayground/UTC--2018-02-28T13-02-05Z--962e5218-8b15-f891-da7d-29a76e4f5c1c
config/keysBkup/parityPlayground/UTC--2018-02-28T13-01-52Z--d0311a83-f0f6-6022-226e-3b942bf807c4 -> chainData/keys/parityPlayground/UTC--2018-02-28T13-01-52Z--d0311a83-f0f6-6022-226e-3b942bf807c4
config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-37Z--f3f992d8-1c66-7891-2795-f137df135075 -> chainData/keys/parityPlayground/UTC--2018-02-28T13-02-37Z--f3f992d8-1c66-7891-2795-f137df135075
config/keysBkup/parityPlayground/UTC--2018-02-28T13-03-47Z--98794f14-6cb2-5778-1adf-1280315035e7 -> chainData/keys/parityPlayground/UTC--2018-02-28T13-03-47Z--98794f14-6cb2-5778-1adf-1280315035e7
config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-23Z--4f7a75f7-b1da-f3cd-9480-4b6183885b09 -> chainData/keys/parityPlayground/UTC--2018-02-28T13-02-23Z--4f7a75f7-b1da-f3cd-9480-4b6183885b09
config/keysBkup/parityPlayground/UTC--2018-02-28T13-03-06Z--37a4c04d-6f61-951e-b43d-a5feefc731ca -> chainData/keys/parityPlayground/UTC--2018-02-28T13-03-06Z--37a4c04d-6f61-951e-b43d-a5feefc731ca
Sealer key in {config}/sealer.txt. Starting sealer node.
2018-08-14 22:20:21 UTC Starting Parity/v1.11.8-stable-92776e4-20180728/x86_64-linux-gnu/rustc1.27.2
2018-08-14 22:20:21 UTC Keys path /var/parity/keys/parityPlayground
2018-08-14 22:20:21 UTC DB path /var/parity/chains/parityPlayground/db/d75fe530a9473053
2018-08-14 22:20:21 UTC Path to dapps /var/parity/dapps
2018-08-14 22:20:21 UTC State DB configuration: fast
2018-08-14 22:20:21 UTC Operating mode: active
2018-08-14 22:20:21 UTC Configured for parityPlayground using AuthorityRound engine
2018-08-14 22:20:26 UTC Public node URL: enode://3056622b316f2d025a3ced401b501dbd7ddbfcd9c01ca7a50801db05396a1ff4e7c35dce4da5eb4fa7c0872771b777eea116c2d48567c83bfbfbfb9e4e757525@172.17.0.2:30303
2018-08-14 22:20:56 UTC    0/25 peers   8 KiB chain 7 KiB db 0 bytes queue 448 bytes sync  RPC:  0 conn,  0 req/s,   0 µs
^C2018-08-14 22:20:57 UTC Finishing work, please wait...
```

Running on Mac OS X for the second time:

```
Highgarden:ParityPlayground kkom$ ./run.sh 
config/keysBkup/parityPlayground -> chainData/keys/parityPlayground
config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-05Z--962e5218-8b15-f891-da7d-29a76e4f5c1c -> chainData/keys/parityPlayground/UTC--2018-02-28T13-02-05Z--962e5218-8b15-f891-da7d-29a76e4f5c1c
config/keysBkup/parityPlayground/UTC--2018-02-28T13-01-52Z--d0311a83-f0f6-6022-226e-3b942bf807c4 -> chainData/keys/parityPlayground/UTC--2018-02-28T13-01-52Z--d0311a83-f0f6-6022-226e-3b942bf807c4
config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-37Z--f3f992d8-1c66-7891-2795-f137df135075 -> chainData/keys/parityPlayground/UTC--2018-02-28T13-02-37Z--f3f992d8-1c66-7891-2795-f137df135075
config/keysBkup/parityPlayground/UTC--2018-02-28T13-03-47Z--98794f14-6cb2-5778-1adf-1280315035e7 -> chainData/keys/parityPlayground/UTC--2018-02-28T13-03-47Z--98794f14-6cb2-5778-1adf-1280315035e7
config/keysBkup/parityPlayground/UTC--2018-02-28T13-02-23Z--4f7a75f7-b1da-f3cd-9480-4b6183885b09 -> chainData/keys/parityPlayground/UTC--2018-02-28T13-02-23Z--4f7a75f7-b1da-f3cd-9480-4b6183885b09
config/keysBkup/parityPlayground/UTC--2018-02-28T13-03-06Z--37a4c04d-6f61-951e-b43d-a5feefc731ca -> chainData/keys/parityPlayground/UTC--2018-02-28T13-03-06Z--37a4c04d-6f61-951e-b43d-a5feefc731ca
Sealer key in {config}/sealer.txt. Starting sealer node.
2018-08-14 22:22:09 UTC Starting Parity/v1.11.8-stable-92776e4-20180728/x86_64-linux-gnu/rustc1.27.2
2018-08-14 22:22:09 UTC Keys path /var/parity/keys/parityPlayground
2018-08-14 22:22:09 UTC DB path /var/parity/chains/parityPlayground/db/d75fe530a9473053
2018-08-14 22:22:09 UTC Path to dapps /var/parity/dapps
2018-08-14 22:22:09 UTC State DB configuration: fast
2018-08-14 22:22:09 UTC Operating mode: active
2018-08-14 22:22:09 UTC Configured for parityPlayground using AuthorityRound engine
2018-08-14 22:22:15 UTC Public node URL: enode://3056622b316f2d025a3ced401b501dbd7ddbfcd9c01ca7a50801db05396a1ff4e7c35dce4da5eb4fa7c0872771b777eea116c2d48567c83bfbfbfb9e4e757525@172.17.0.2:30303

^C2018-08-14 22:22:39 UTC Finishing work, please wait...
```

Checking `.gitignore`:

```
Highgarden:ParityPlayground kkom$ git status
On branch copy-keys-better
Your branch is up to date with 'origin/copy-keys-better'.

nothing to commit, working tree clean
Highgarden:ParityPlayground kkom$ ls -r chainData/*
chainData/signer:

chainData/network:
key

chainData/keys:
parityPlayground

chainData/dapps:

chainData/chains:
ver.lock		parityPlayground

chainData/cache:
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/daniel-jozsef/parityplayground/3)
<!-- Reviewable:end -->
